### PR TITLE
Fix NO_PUBKEY apt error

### DIFF
--- a/ebusd-default-bookworm.list
+++ b/ebusd-default-bookworm.list
@@ -1,1 +1,1 @@
-deb https://repo.ebusd.eu/apt/default/bookworm bookworm main
+deb [signed-by=/etc/apt/keyrings/ebusd.gpg] https://repo.ebusd.eu/apt/default/bookworm bookworm main

--- a/ebusd-nomqtt-bookworm.list
+++ b/ebusd-nomqtt-bookworm.list
@@ -1,1 +1,1 @@
-deb https://repo.ebusd.eu/apt/nomqtt/bookworm bookworm main
+deb [signed-by=/etc/apt/keyrings/ebusd.gpg] https://repo.ebusd.eu/apt/nomqtt/bookworm bookworm main


### PR DESCRIPTION
This relates to issue https://github.com/john30/ebusd-debian/issues/16 where apt was not finding the public key